### PR TITLE
Add environment variable names for hardware data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.hobbit</groupId>
     <artifactId>core</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.10-SNAPSHOT</version>
 
     <!-- LICENSE -->
     <licenses>

--- a/src/main/java/org/hobbit/core/Constants.java
+++ b/src/main/java/org/hobbit/core/Constants.java
@@ -55,6 +55,10 @@ public final class Constants {
 
     public static final String ACKNOWLEDGEMENT_FLAG_KEY = "ACKNOWLEDGEMENT_FLAG";
 
+    public static final String HARDWARE_NUMBER_OF_NODES_KEY = "HOBBIT_HARDWARE_NODES";
+
+    public static final String HARDWARE_INFO_KEY = "HOBBIT_HARDWARE_INFO";
+
     // =============== RABBIT CONSTANTS ===============
 
     /**


### PR DESCRIPTION
Adds two environment variables for hardware data feature: https://github.com/hobbit-project/platform/issues/169

`HOBBIT_HARDWARE_NODES` is for number of nodes in swarm, `HOBBIT_HARDWARE_INFO` is for RDF model with more information. Ideas for better names welcome before merging.