### PR TITLE
Hashing of resource contents to determine its URL

### DIFF
--- a/src/main/java/org/hobbit/utils/rdf/HashingRDFVisitor.java
+++ b/src/main/java/org/hobbit/utils/rdf/HashingRDFVisitor.java
@@ -1,0 +1,67 @@
+/**
+ * This file is part of core.
+ *
+ * core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.hobbit.utils.rdf;
+
+import org.apache.jena.rdf.model.AnonId;
+import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.rdf.model.RDFVisitor;
+import org.apache.jena.rdf.model.Resource;
+
+/**
+ * A class for serializing URI and literal nodes
+ * in the format used for hashing.
+ *
+ * @author Denis Kuchelev
+ *
+ */
+public class HashingRDFVisitor implements RDFVisitor {
+
+    public static HashingRDFVisitor instance = new HashingRDFVisitor();
+
+    /**
+        Method to call when visiting a blank node r with identifier id.
+        This implementation does not expect any blank nodes.
+        @param r the blank RDF node being visited
+        @param id the identifier of that node
+        @return null
+    */
+    @Override
+    public String visitBlank(Resource r, AnonId id) {
+        return null;
+    }
+
+    /**
+        Method to call when visiting a URI node r with the given uri.
+        @param r the URI node being visited
+        @param uri the URI string of that node
+        @return value to be returned from the visit
+    */
+    @Override
+    public String visitURI(Resource r, String uri) {
+        return "<" + uri + ">";
+    }
+
+    /**
+        Method to call when visiting a literal RDF node l.
+        @param l the RDF Literal node
+        @return a value to be returned from the visit
+    */
+    @Override
+    public String visitLiteral(Literal l) {
+        return "\"" + l.getString() + "\"";
+    }
+}

--- a/src/main/java/org/hobbit/utils/rdf/HashingRDFVisitor.java
+++ b/src/main/java/org/hobbit/utils/rdf/HashingRDFVisitor.java
@@ -37,11 +37,11 @@ public class HashingRDFVisitor implements RDFVisitor {
         This implementation does not expect any blank nodes.
         @param r the blank RDF node being visited
         @param id the identifier of that node
-        @return null
+        @throws IllegalStateException
     */
     @Override
     public String visitBlank(Resource r, AnonId id) {
-        return null;
+        throw new IllegalStateException("This implementation does not expect any blank nodes.");
     }
 
     /**

--- a/src/test/java/org/hobbit/utils/rdf/HashResourceTest.java
+++ b/src/test/java/org/hobbit/utils/rdf/HashResourceTest.java
@@ -1,0 +1,81 @@
+/**
+ * This file is part of core.
+ *
+ * core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.hobbit.utils.rdf;
+
+import org.apache.jena.rdf.model.impl.StmtIteratorImpl;
+import org.apache.jena.rdf.model.Statement;
+import java.util.stream.Stream;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.impl.StatementImpl;
+import static org.junit.Assert.*;
+import org.junit.*;
+
+public class HashResourceTest {
+
+    private Model m;
+
+    @Before
+    public void setUp() throws Exception {
+        m = ModelFactory.createDefaultModel();
+    }
+
+    @Test
+    public void testHashResourceWithLiteral() {
+        String hash = RdfHelper.hashProperties(new StmtIteratorImpl(Stream.of(
+            (Statement) new StatementImpl(
+                m.createResource(RdfHelper.HASH_SELF_URI),
+                m.createProperty("http://example.org/exampleProperty"),
+                m.createLiteral("exampleLiteralValue"))
+        ).iterator()));
+
+        assertEquals("Hash of resource with a single literal value",
+                "7d382754e28fd2ee70f6dbdb5feb0a4caa9d4dbf", hash);
+    }
+
+    @Test
+    public void testHashResourceWithURI() {
+        String hash = RdfHelper.hashProperties(new StmtIteratorImpl(Stream.of(
+            (Statement) new StatementImpl(
+                m.createResource(RdfHelper.HASH_SELF_URI),
+                m.createProperty("http://example.org/exampleProperty"),
+                m.createResource("http://example.org/ExampleResource"))
+        ).iterator()));
+
+        assertEquals("Hash of resource with a single URI value",
+                "76129f18357ee830f85f21565c8efadb7b0a567e", hash);
+    }
+
+    @Test
+    public void testHashResourceWithSeveralProperties() {
+        String hash = RdfHelper.hashProperties(new StmtIteratorImpl(Stream.of(
+            (Statement) new StatementImpl(
+                m.createResource(RdfHelper.HASH_SELF_URI),
+                m.createProperty("http://example.org/exampleProperty"),
+                m.createLiteral("exampleValue2")),
+            new StatementImpl(
+                m.createResource(RdfHelper.HASH_SELF_URI),
+                m.createProperty("http://example.org/exampleProperty"),
+                m.createLiteral("exampleValue1"))
+        ).iterator()));
+
+        assertEquals("Hash of resource with several properties",
+                "8b775c924725d8dc8d2e2fc6d1dd74d8880248a7", hash);
+    }
+
+}


### PR DESCRIPTION
Taking this utility from https://github.com/hobbit-project/platform/pull/385 to core with little rework: now a `StmtIterator` with statements is passed instead of resource.