### PR TITLE
Only add RabbitMQ host env if there isn't any

### DIFF
--- a/src/main/java/org/hobbit/core/components/AbstractCommandReceivingComponent.java
+++ b/src/main/java/org/hobbit/core/components/AbstractCommandReceivingComponent.java
@@ -260,11 +260,12 @@ public abstract class AbstractCommandReceivingComponent extends AbstractComponen
 
             // Only add RabbitMQ host env if there isn't any.
             if (Stream.of(envVariables).noneMatch(kv -> kv.startsWith(Constants.RABBIT_MQ_HOST_NAME_KEY + "="))) {
-                envVariables = Arrays.copyOf(envVariables, envVariables.length + 1);
+                envVariables = Arrays.copyOf(envVariables, envVariables.length + 2);
                 envVariables[envVariables.length - 1] = Constants.RABBIT_MQ_HOST_NAME_KEY + "=" + rabbitMQHostName;
+            } else {
+                envVariables = Arrays.copyOf(envVariables, envVariables.length + 1);
             }
 
-            envVariables = Arrays.copyOf(envVariables, envVariables.length + 1);
             envVariables[envVariables.length - 1] = Constants.HOBBIT_SESSION_ID_KEY + "=" + getHobbitSessionId();
 
             initResponseQueue();

--- a/src/test/java/org/hobbit/core/components/ContainerEnvironmentTest.java
+++ b/src/test/java/org/hobbit/core/components/ContainerEnvironmentTest.java
@@ -1,0 +1,129 @@
+/**
+ * This file is part of core.
+ *
+ * core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.hobbit.core.components;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.hobbit.core.components.dummy.DummyCommandReceivingComponent;
+import org.hobbit.core.Constants;
+import org.hobbit.core.TestConstants;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+
+@RunWith(Parameterized.class)
+public class ContainerEnvironmentTest {
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+    private AbstractCommandReceivingComponent component;
+
+    @Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            {
+                // input
+                null,
+                // expected output
+                new String[] {
+                    Constants.RABBIT_MQ_HOST_NAME_KEY + "=" + TestConstants.RABBIT_HOST,
+                    Constants.HOBBIT_SESSION_ID_KEY + "=0",
+                }
+            },
+            {
+                // input
+                new String[] {},
+                // expected output
+                new String[] {
+                    Constants.RABBIT_MQ_HOST_NAME_KEY + "=" + TestConstants.RABBIT_HOST,
+                    Constants.HOBBIT_SESSION_ID_KEY + "=0",
+                }
+            },
+            {
+                // input
+                new String[] {
+                    "A=B",
+                    "C=",
+                },
+                // expected output
+                new String[] {
+                    "A=B",
+                    "C=",
+                    Constants.RABBIT_MQ_HOST_NAME_KEY + "=" + TestConstants.RABBIT_HOST,
+                    Constants.HOBBIT_SESSION_ID_KEY + "=0",
+                }
+            },
+            {
+                // input
+                new String[] {
+                    Constants.RABBIT_MQ_HOST_NAME_KEY + "=another.rabbit",
+                },
+                // expected output
+                new String[] {
+                    Constants.RABBIT_MQ_HOST_NAME_KEY + "=another.rabbit",
+                    Constants.HOBBIT_SESSION_ID_KEY + "=0",
+                }
+            },
+            {
+                // input
+                new String[] {
+                    "A=B",
+                    Constants.RABBIT_MQ_HOST_NAME_KEY + "=another.rabbit",
+                    "C=",
+                },
+                // expected output
+                new String[] {
+                    "A=B",
+                    Constants.RABBIT_MQ_HOST_NAME_KEY + "=another.rabbit",
+                    "C=",
+                    Constants.HOBBIT_SESSION_ID_KEY + "=0",
+                }
+            },
+        });
+    }
+
+    @Parameter(0)
+    public String[] passedEnvVariables;
+
+    @Parameter(1)
+    public String[] expectedEnvVariables;
+
+    @Before
+    public void setUp() throws Exception {
+        environmentVariables.set(Constants.RABBIT_MQ_HOST_NAME_KEY, TestConstants.RABBIT_HOST);
+        environmentVariables.set(Constants.HOBBIT_SESSION_ID_KEY, "0");
+
+        component = new DummyCommandReceivingComponent();
+        component.init();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        component.close();
+    }
+
+    @Test
+    public void test() throws Exception {
+        assertArrayEquals(expectedEnvVariables, component.extendContainerEnvVariables(passedEnvVariables));
+    }
+}

--- a/src/test/java/org/hobbit/core/components/dummy/DummyCommandReceivingComponent.java
+++ b/src/test/java/org/hobbit/core/components/dummy/DummyCommandReceivingComponent.java
@@ -1,0 +1,32 @@
+/**
+ * This file is part of core.
+ *
+ * core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.hobbit.core.components.dummy;
+
+import org.hobbit.core.components.AbstractCommandReceivingComponent;
+
+import org.junit.Ignore;
+
+@Ignore
+public class DummyCommandReceivingComponent extends AbstractCommandReceivingComponent {
+    @Override
+    public void run() {
+    }
+
+    @Override
+    public void receiveCommand(byte command, byte[] data) {
+    }
+}


### PR DESCRIPTION
Would be helpful when testing projects based on HOBBIT SDK.