### PR TITLE
v1.0.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.hobbit</groupId>
     <artifactId>core</artifactId>
-    <version>1.0.17</version>
+    <version>1.0.18-SNAPSHOT</version>
 
     <!-- LICENSE -->
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
         <slf4j.version>1.7.15</slf4j.version>
-        <junit.version>4.11</junit.version>
+        <junit.version>4.12</junit.version>
     </properties>
     <!-- TODO Add license -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.hobbit</groupId>
     <artifactId>core</artifactId>
-    <version>1.0.18-SNAPSHOT</version>
+    <version>1.0.18</version>
 
     <!-- LICENSE -->
     <licenses>

--- a/src/main/java/org/hobbit/core/components/AbstractBenchmarkController.java
+++ b/src/main/java/org/hobbit/core/components/AbstractBenchmarkController.java
@@ -285,7 +285,7 @@ public abstract class AbstractBenchmarkController extends AbstractPlatformConnec
             LOGGER.error(errorMsg);
             throw new IllegalStateException(errorMsg, e);
         }
-        LOGGER.debug("Waiting for {} Data Generators to be ready.", taskGenContainerIds.size());
+        LOGGER.debug("Waiting for {} Task Generators to be ready.", taskGenContainerIds.size());
         try {
             taskGenReadyMutex.acquire(taskGenContainerIds.size());
         } catch (InterruptedException e) {

--- a/src/main/java/org/hobbit/core/components/AbstractBenchmarkController.java
+++ b/src/main/java/org/hobbit/core/components/AbstractBenchmarkController.java
@@ -211,9 +211,10 @@ public abstract class AbstractBenchmarkController extends AbstractPlatformConnec
         String containerId;
         String variables[] = envVariables != null ? Arrays.copyOf(envVariables, envVariables.length + 2)
                 : new String[2];
+        // NOTE: Count only includes generators created within this method call.
         variables[variables.length - 2] = Constants.GENERATOR_COUNT_KEY + "=" + numberOfGenerators;
         for (int i = 0; i < numberOfGenerators; ++i) {
-            variables[variables.length - 1] = Constants.GENERATOR_ID_KEY + "=" + i;
+            variables[variables.length - 1] = Constants.GENERATOR_ID_KEY + "=" + generatorIds.size();
             containerId = createContainer(generatorImageName, variables);
             if (containerId != null) {
                 generatorIds.add(containerId);

--- a/src/main/java/org/hobbit/core/components/AbstractBenchmarkController.java
+++ b/src/main/java/org/hobbit/core/components/AbstractBenchmarkController.java
@@ -294,13 +294,15 @@ public abstract class AbstractBenchmarkController extends AbstractPlatformConnec
             LOGGER.error(errorMsg);
             throw new IllegalStateException(errorMsg, e);
         }
-        LOGGER.debug("Waiting for Evaluation Storage to be ready.");
-        try {
-            evalStoreReadyMutex.acquire();
-        } catch (InterruptedException e) {
-            String errorMsg = "Interrupted while waiting for the evaluation storage to be ready.";
-            LOGGER.error(errorMsg);
-            throw new IllegalStateException(errorMsg, e);
+        if (evalStoreContainerId != null) {
+            LOGGER.debug("Waiting for Evaluation Storage to be ready.");
+            try {
+                evalStoreReadyMutex.acquire();
+            } catch (InterruptedException e) {
+                String errorMsg = "Interrupted while waiting for the evaluation storage to be ready.";
+                LOGGER.error(errorMsg);
+                throw new IllegalStateException(errorMsg, e);
+            }
         }
     }
 
@@ -400,13 +402,15 @@ public abstract class AbstractBenchmarkController extends AbstractPlatformConnec
             LOGGER.error(errorMsg);
             throw new IllegalStateException(errorMsg, e);
         }
-        LOGGER.debug("Waiting for the evaluation storage to finish.");
-        try {
-            evalStoreTerminatedMutex.acquire();
-        } catch (InterruptedException e) {
-            String errorMsg = "Interrupted while waiting for the evaluation storage to terminate.";
-            LOGGER.error(errorMsg);
-            throw new IllegalStateException(errorMsg, e);
+        if (evalStoreContainerId != null) {
+            LOGGER.debug("Waiting for the evaluation storage to finish.");
+            try {
+                evalStoreTerminatedMutex.acquire();
+            } catch (InterruptedException e) {
+                String errorMsg = "Interrupted while waiting for the evaluation storage to terminate.";
+                LOGGER.error(errorMsg);
+                throw new IllegalStateException(errorMsg, e);
+            }
         }
     }
 

--- a/src/main/java/org/hobbit/core/components/AbstractBenchmarkController.java
+++ b/src/main/java/org/hobbit/core/components/AbstractBenchmarkController.java
@@ -214,6 +214,8 @@ public abstract class AbstractBenchmarkController extends AbstractPlatformConnec
         // NOTE: Count only includes generators created within this method call.
         variables[variables.length - 2] = Constants.GENERATOR_COUNT_KEY + "=" + numberOfGenerators;
         for (int i = 0; i < numberOfGenerators; ++i) {
+            // At the start generatorIds is empty, and new generators are added to it immediately.
+            // Current size of that set is used to make IDs for new generators.
             variables[variables.length - 1] = Constants.GENERATOR_ID_KEY + "=" + generatorIds.size();
             containerId = createContainer(generatorImageName, variables);
             if (containerId != null) {

--- a/src/main/java/org/hobbit/core/components/AbstractCommandReceivingComponent.java
+++ b/src/main/java/org/hobbit/core/components/AbstractCommandReceivingComponent.java
@@ -503,13 +503,14 @@ public abstract class AbstractCommandReceivingComponent extends AbstractComponen
                                 LOGGER.error("Received a message with correlationId ({}) not in map ({})", key, responseFutures.keySet());
                             }
                         } else {
+                            LOGGER.warn("Received a message with null correlationId. This is an error unless the other component uses an older version of HOBBIT core library.");
                             Iterator<SettableFuture<String>> iter = responseFutures.values().iterator();
                             if (iter.hasNext()) {
-                                LOGGER.error("Received a message with null correlationId. This is an error unless the other component uses an older version of HOBBIT core library. Correlating with the eldest request as a workaround...");
+                                LOGGER.info("Correlating with the eldest request as a workaround.");
                                 future = iter.next();
                                 iter.remove();
                             } else {
-                                LOGGER.error("Received a message with null correlationId. This is an error unless the other component uses an older version of HOBBIT core library. There are no pending requests.");
+                                LOGGER.error("There are no pending requests.");
                             }
                         }
 

--- a/src/main/java/org/hobbit/core/components/AbstractCommandReceivingComponent.java
+++ b/src/main/java/org/hobbit/core/components/AbstractCommandReceivingComponent.java
@@ -399,6 +399,36 @@ public abstract class AbstractCommandReceivingComponent extends AbstractComponen
      * @param envVariables
      *            environment variables that should be added to the created
      *            container
+     * @return the Future object with the name of the container instance or null if an error occurred
+     */
+    protected Future<String> createContainerAsync(String imageName, String containerType, String[] envVariables) {
+        return createContainerAsync(imageName, containerType, envVariables, null);
+    }
+
+    /**
+     * This method sends a {@link Commands#DOCKER_CONTAINER_START} command to
+     * create and start an instance of the given image using the given
+     * environment variables.
+     *
+     * <p>
+     * Note that the containerType parameter should have one of the following
+     * values.
+     * <ul>
+     * <li>{@link Constants#CONTAINER_TYPE_BENCHMARK} if this container is part
+     * of a benchmark.</li>
+     * <li>{@link Constants#CONTAINER_TYPE_DATABASE} if this container is part
+     * of a benchmark but should be located on a storage node.</li>
+     * <li>{@link Constants#CONTAINER_TYPE_SYSTEM} if this container is part of
+     * a benchmarked system.</li>
+     * </ul>
+     *
+     * @param imageName
+     *            the name of the image of the docker container
+     * @param containerType
+     *            the type of the container
+     * @param envVariables
+     *            environment variables that should be added to the created
+     *            container
      * @param netAliases
      *            network aliases that should be added to the created container
      * @return the Future object with the name of the container instance or null if an error occurred

--- a/src/main/java/org/hobbit/core/components/AbstractCommandReceivingComponent.java
+++ b/src/main/java/org/hobbit/core/components/AbstractCommandReceivingComponent.java
@@ -260,11 +260,12 @@ public abstract class AbstractCommandReceivingComponent extends AbstractComponen
 
             // Only add RabbitMQ host env if there isn't any.
             if (Stream.of(envVariables).noneMatch(kv -> kv.startsWith(Constants.RABBIT_MQ_HOST_NAME_KEY + "="))) {
-                envVariables = Arrays.copyOf(envVariables, envVariables.length + 1);
+                envVariables = Arrays.copyOf(envVariables, envVariables.length + 2);
                 envVariables[envVariables.length - 1] = Constants.RABBIT_MQ_HOST_NAME_KEY + "=" + rabbitMQHostName;
+            } else {
+                envVariables = Arrays.copyOf(envVariables, envVariables.length + 1);
             }
 
-            envVariables = Arrays.copyOf(envVariables, envVariables.length + 1);
             envVariables[envVariables.length - 1] = Constants.HOBBIT_SESSION_ID_KEY + "=" + getHobbitSessionId();
 
             initResponseQueue();

--- a/src/main/java/org/hobbit/core/components/AbstractComponent.java
+++ b/src/main/java/org/hobbit/core/components/AbstractComponent.java
@@ -92,14 +92,15 @@ public abstract class AbstractComponent implements Component {
 
     protected Connection createConnection() throws Exception {
         Connection connection = null;
+        Exception exception = null;
         for (int i = 0; (connection == null) && (i <= NUMBER_OF_RETRIES_TO_CONNECT_TO_RABBIT_MQ); ++i) {
             try {
                 connection = connectionFactory.newConnection();
             } catch (Exception e) {
                 if (i < NUMBER_OF_RETRIES_TO_CONNECT_TO_RABBIT_MQ) {
                     long waitingTime = START_WAITING_TIME_BEFORE_RETRY * (i + 1);
-                    LOGGER.warn("Couldn't connect to RabbitMQ with try #" + i + ". Next try in " + waitingTime + "ms.",
-                            e);
+                    LOGGER.warn("Couldn't connect to RabbitMQ with try #" + i + ". Next try in " + waitingTime + "ms.");
+                    exception = e;
                     try {
                         Thread.sleep(waitingTime);
                     } catch (Exception e2) {
@@ -111,8 +112,8 @@ public abstract class AbstractComponent implements Component {
         if (connection == null) {
             String msg = "Couldn't connect to RabbitMQ after " + NUMBER_OF_RETRIES_TO_CONNECT_TO_RABBIT_MQ
                     + " retries.";
-            LOGGER.error(msg);
-            throw new Exception(msg);
+            LOGGER.error(msg, exception);
+            throw new Exception(msg, exception);
         }
         return connection;
     }

--- a/src/main/java/org/hobbit/core/data/StartCommandData.java
+++ b/src/main/java/org/hobbit/core/data/StartCommandData.java
@@ -25,12 +25,14 @@ public class StartCommandData {
      */
     public String parent;
     public String[] environmentVariables;
+    public String[] networkAliases;
 
-    public StartCommandData(String image, String type, String parent, String[] environmentVariables) {
+    public StartCommandData(String image, String type, String parent, String[] environmentVariables, String[] netAliases) {
         this.image = image;
         this.type = type;
         this.parent = parent;
         this.environmentVariables = environmentVariables;
+        this.networkAliases = netAliases;
     }
 
     public String getImage() {
@@ -63,6 +65,14 @@ public class StartCommandData {
 
     public void setEnvironmentVariables(String[] environmentVariables) {
         this.environmentVariables = environmentVariables;
+    }
+
+    public String[] getNetworkAliases() {
+        return networkAliases;
+    }
+
+    public void setNetworkAliases(String[] networkAliases) {
+        this.networkAliases = networkAliases;
     }
 
     @Override

--- a/src/main/java/org/hobbit/encryption/AES.java
+++ b/src/main/java/org/hobbit/encryption/AES.java
@@ -19,7 +19,7 @@ public class AES {
     private static final Logger LOGGER = LoggerFactory.getLogger(AES.class);
 
     private SecretKey secretKey = null;
-    private static String cipherAlgorithm = "AES/ECB/PKCS5PADDING";
+    protected static final String CIPHER_ALGORITHM = "AES/ECB/PKCS5PADDING";
 
     public AES(String password, String salt) {
         this.secretKey = AESKeyGenerator.generate(password, salt);
@@ -79,7 +79,7 @@ public class AES {
     private Cipher getCipherInstance() throws AESException {
         Cipher cipher = null;
         try {
-            cipher = Cipher.getInstance(this.cipherAlgorithm);
+            cipher = Cipher.getInstance(CIPHER_ALGORITHM);
         } catch (NoSuchAlgorithmException e) {
             LOGGER.error("Error initializing AES encryption. AES algorithm not found.", e);
             throw new AESException();

--- a/src/main/java/org/hobbit/encryption/AESException.java
+++ b/src/main/java/org/hobbit/encryption/AESException.java
@@ -1,10 +1,13 @@
 package org.hobbit.encryption;
 
 public class AESException extends Exception {
-    private static String defaultMessage = "Error initializing encryption algorithm AES/ECB/PKCS5PADDING. " +
-        "Please check your Java distribution for the availability of this type of encryption. " +
-        "To fall back to unencrypted communication between storage-service and other services " +
-        "unset AES_PASSWORD and AES_SALT environmental variables.";
+
+    private static final long serialVersionUID = 1L;
+
+    private static String defaultMessage = "Error initializing encryption algorithm " + AES.CIPHER_ALGORITHM + ". "
+            + "Please check your Java distribution for the availability of this type of encryption. "
+            + "To fall back to unencrypted communication between storage-service and other services "
+            + "unset AES_PASSWORD and AES_SALT environmental variables.";
 
     public AESException() {
         super(defaultMessage);

--- a/src/main/java/org/hobbit/utils/EnvVariables.java
+++ b/src/main/java/org/hobbit/utils/EnvVariables.java
@@ -595,6 +595,176 @@ public class EnvVariables {
 
     /**
      * Returns the value of the environmental variable with the given name as
+     * {@code long} or throws an {@link IllegalStateException} if the variable can
+     * not be found or an error occurs.
+     * 
+     * @param name
+     *            name of the environmental variable which should be accessed
+     * @return the variable value
+     * @throws IllegalStateException
+     *             if the variable can not be found or an error occurs.
+     */
+    public static long getLong(String name) throws IllegalStateException {
+        return getLongValue(name, 0, null, true, false);
+    }
+
+    /**
+     * Returns the value of the environmental variable with the given name as
+     * {@code long} or the default value if the variable can not be found or an error
+     * occurs.
+     * 
+     * @param name
+     *            name of the environmental variable which should be accessed
+     * @param defaultValue
+     *            the default value which will be returned if the variable can not
+     *            be found or if an error occurs.
+     * @return the variable value or the default value if an error occurred and a
+     *         default value is available.
+     */
+    public static long getLong(String name, long defaultValue) {
+        return getLongValue(name, defaultValue, null, false, true);
+    }
+
+    /**
+     * Returns the value of the environmental variable with the given name as
+     * {@code long} or the default value if the variable can not be found or an error
+     * occurs.
+     * 
+     * @param name
+     *            name of the environmental variable which should be accessed
+     * @param defaultValueFactory
+     *            A factory method which can be used to generate a default value
+     *            which will be returned if the variable can not be found or if an
+     *            error occurs.
+     * @return the variable value or the default value if an error occurred and a
+     *         default value is available.
+     */
+    public static long getLong(String name, Supplier<Long> defaultValueFactory) {
+        return getLongValue(name, defaultValueFactory, null, false);
+    }
+
+    /**
+     * Returns the value of the environmental variable with the given name as
+     * {@code long} or throws an {@link IllegalStateException} if the variable can
+     * not be found or an error occurs.
+     * 
+     * @param name
+     *            name of the environmental variable which should be accessed
+     * @param logger
+     *            the {@link Logger} which will be used to log errors if they occur.
+     * @return the variable value
+     * @throws IllegalStateException
+     *             if the variable can not be found or an error occurs.
+     */
+    public static long getLong(String name, Logger logger) throws IllegalStateException {
+        return getLongValue(name, 0, logger, true, false);
+    }
+
+    /**
+     * Returns the value of the environmental variable with the given name as
+     * {@code long} or the default value if the variable can not be found or an error
+     * occurs.
+     * 
+     * @param name
+     *            name of the environmental variable which should be accessed
+     * @param defaultValue
+     *            the default value which will be returned if the variable can not
+     *            be found or if an error occurs.
+     * @param logger
+     *            the {@link Logger} which will be used to log errors if they occur.
+     * @return the variable value or the default value if an error occurred and a
+     *         default value is available.
+     */
+    public static long getLong(String name, long defaultValue, Logger logger) {
+        return getLongValue(name, defaultValue, logger, false, true);
+    }
+
+    /**
+     * Returns the value of the environmental variable with the given name as
+     * {@code long} or the default value if the variable can not be found or an error
+     * occurs.
+     * 
+     * @param name
+     *            name of the environmental variable which should be accessed
+     * @param defaultValueFactory
+     *            A factory method which can be used to generate a default value
+     *            which will be returned if the variable can not be found or if an
+     *            error occurs.
+     * @param logger
+     *            the {@link Logger} which will be used to log errors if they occur.
+     * @return the variable value or the default value if an error occurred and a
+     *         default value is available.
+     */
+    public static long getLong(String name, Supplier<Long> defaultValueFactory, Logger logger) {
+        return getLongValue(name, defaultValueFactory, logger, false);
+    }
+
+    /**
+     * Internal method defining the default value factory function before calling
+     * {@link #getLongValue(String, Supplier, Logger, boolean)}.
+     * 
+     * @param name
+     *            name of the environmental variable which should be accessed
+     * @param conversion
+     *            the function which is used to convert the {@link String} of the
+     *            variable value into the expected value type. It is assumed that
+     *            this function will throw an exception if an error occurs.
+     * @param defaultValue
+     *            the default value which will be returned if the variable can not
+     *            be found or if an error occurs.
+     * @param logger
+     *            the {@link Logger} which will be used to log errors if they occur.
+     * @param exceptionWhenFailing
+     *            flag indicating whether an exception should be thrown if an error
+     *            occurs.
+     * @param hasDefaultValue
+     *            flag indicating whether a default value has been provided.
+     * @return the variable value converted to the expected value or the default
+     *         value if an error occurred and a default value is available.
+     * @throws IllegalStateException
+     *             if exceptionWhenFailing is set to {@code true} and one of the
+     *             following two errors occurs: 1) the variable is not available or
+     *             2) the conversion function throws an exception.
+     */
+    protected static long getLongValue(String name, long defaultValue, Logger logger, boolean exceptionWhenFailing,
+            boolean hasDefaultValue) throws IllegalStateException {
+        return getVariableValue(name, Long::parseLong, hasDefaultValue ? (() -> defaultValue) : null, logger,
+                exceptionWhenFailing);
+    }
+
+    /**
+     * Internal method defining the conversion function before calling
+     * {@link #getVariableValue(String, Function, Object, Logger)}.
+     * 
+     * @param name
+     *            name of the environmental variable which should be accessed
+     * @param conversion
+     *            the function which is used to convert the {@link String} of the
+     *            variable value into the expected value type. It is assumed that
+     *            this function will throw an exception if an error occurs.
+     * @param defaultValueFactory
+     *            A factory method which can be used to generate a default value
+     *            which will be returned if the variable can not be found or if an
+     *            error occurs.
+     * @param logger
+     *            the {@link Logger} which will be used to log errors if they occur.
+     * @param exceptionWhenFailing
+     *            flag indicating whether an exception should be thrown if an error
+     *            occurs.
+     * @return the variable value converted to the expected value or the default
+     *         value if an error occurred and a default value is available.
+     * @throws IllegalStateException
+     *             if exceptionWhenFailing is set to {@code true} and one of the
+     *             following two errors occurs: 1) the variable is not available or
+     *             2) the conversion function throws an exception.
+     */
+    protected static long getLongValue(String name, Supplier<Long> defaultValueFactory, Logger logger,
+            boolean exceptionWhenFailing) throws IllegalStateException {
+        return getLongValue(name, defaultValueFactory, logger, exceptionWhenFailing);
+    }
+
+    /**
+     * Returns the value of the environmental variable with the given name as
      * {@code boolean} or throws an {@link IllegalStateException} if the variable
      * can not be found or an error occurs.
      * 

--- a/src/test/java/org/hobbit/core/components/BenchmarkControllerTest.java
+++ b/src/test/java/org/hobbit/core/components/BenchmarkControllerTest.java
@@ -32,6 +32,7 @@ import org.hobbit.core.Constants;
 import org.hobbit.core.TestConstants;
 import org.hobbit.core.components.dummy.DummyComponentExecutor;
 import org.hobbit.core.rabbit.RabbitMQUtils;
+import org.hobbit.vocab.HobbitExperiments;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -86,7 +87,7 @@ public class BenchmarkControllerTest extends AbstractBenchmarkController {
         environmentVariables.set(Constants.HOBBIT_SESSION_ID_KEY, sessionId);
         environmentVariables.set(Constants.BENCHMARK_PARAMETERS_MODEL_KEY,
                 "{ \"@id\" : \"http://w3id.org/hobbit/experiments#New\", \"@type\" : \"http://w3id.org/hobbit/vocab#Experiment\" }");
-        environmentVariables.set(Constants.HOBBIT_EXPERIMENT_URI_KEY, Constants.EXPERIMENT_URI_NS + sessionId);
+        environmentVariables.set(Constants.HOBBIT_EXPERIMENT_URI_KEY, HobbitExperiments.getExperimentURI(sessionId));
         // Needed for the generators
         environmentVariables.set(Constants.GENERATOR_ID_KEY, "0");
         environmentVariables.set(Constants.GENERATOR_COUNT_KEY, "1");

--- a/src/test/java/org/hobbit/core/components/ContainerCreationNoCorrelationTest.java
+++ b/src/test/java/org/hobbit/core/components/ContainerCreationNoCorrelationTest.java
@@ -1,0 +1,115 @@
+/**
+ * This file is part of core.
+ *
+ * core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.hobbit.core.components;
+
+import org.hobbit.core.components.dummy.DummyComponentExecutor;
+import java.util.Random;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.MessageProperties;
+import org.hobbit.core.rabbit.RabbitMQUtils;
+import java.io.IOException;
+import org.hobbit.core.Commands;
+import org.hobbit.core.components.dummy.AbstractDummyPlatformController;
+import org.hobbit.core.data.StartCommandData;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.hobbit.core.components.dummy.DummyCommandReceivingComponent;
+import org.hobbit.core.Constants;
+import org.hobbit.core.TestConstants;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.Test;
+import org.junit.Rule;
+import org.junit.rules.Stopwatch;
+import static org.junit.Assert.*;
+
+
+public class ContainerCreationNoCorrelationTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ContainerCreationNoCorrelationTest.class);
+
+    private DummyPlatformController platformController = null;
+
+    private static final String HOBBIT_SESSION_ID = "123";
+
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+    private AbstractCommandReceivingComponent component;
+
+    @Rule
+    public Stopwatch stopwatch = new Stopwatch() {};
+
+    @Before
+    public void setUp() throws Exception {
+        environmentVariables.set(Constants.RABBIT_MQ_HOST_NAME_KEY, TestConstants.RABBIT_HOST);
+        environmentVariables.set(Constants.HOBBIT_SESSION_ID_KEY, "0");
+
+        platformController = new DummyPlatformController(HOBBIT_SESSION_ID);
+        DummyComponentExecutor platformExecutor = new DummyComponentExecutor(platformController);
+        Thread platformThread = new Thread(platformExecutor);
+        platformThread.start();
+        platformController.waitForControllerBeingReady();
+
+        component = new DummyCommandReceivingComponent();
+        component.init();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        component.close();
+        platformController.terminate();
+    }
+
+    @Test(timeout = 1000)
+    public void test() throws Exception {
+        Future<String> container1 = component.createContainerAsync("hello-world", null, new String[]{"ID=1"});
+        Future<String> container2 = component.createContainerAsync("hello-world", null, new String[]{"ID=2"});
+        String containerId1 = container1.get();
+        String containerId2 = container2.get();
+        assertEquals("IDs of asynchronously created containers", "1;2", containerId1 + ";" + containerId2);
+    }
+
+    protected static class DummyPlatformController extends AbstractDummyPlatformController {
+        public DummyPlatformController(String sessionId) {
+            super(false);
+            addCommandHeaderId(sessionId);
+        }
+
+        public void receiveCommand(byte command, byte[] data, String sessionId, AMQP.BasicProperties props) {
+            if (command == Commands.DOCKER_CONTAINER_START) {
+                String[] envVars = gson.fromJson(RabbitMQUtils.readString(data), StartCommandData.class).getEnvironmentVariables();
+                String containerId = Stream.of(envVars).filter(kv -> kv.startsWith("ID=")).findAny().get().split("=", 2)[1];
+
+                try {
+                    AMQP.BasicProperties.Builder propsBuilder = new AMQP.BasicProperties.Builder();
+                    propsBuilder.deliveryMode(2);
+                    AMQP.BasicProperties replyProps = propsBuilder.build();
+
+                    cmdChannel.basicPublish("", props.getReplyTo(), replyProps,
+                            RabbitMQUtils.writeString(containerId));
+                } catch (IOException e) {
+                    LOGGER.error("Exception in receiveCommand", e);
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/org/hobbit/core/components/ContainerCreationNoCorrelationTest.java
+++ b/src/test/java/org/hobbit/core/components/ContainerCreationNoCorrelationTest.java
@@ -81,8 +81,8 @@ public class ContainerCreationNoCorrelationTest {
 
     @Test(timeout = 1000)
     public void test() throws Exception {
-        Future<String> container1 = component.createContainerAsync("hello-world", null, new String[]{"ID=1"});
-        Future<String> container2 = component.createContainerAsync("hello-world", null, new String[]{"ID=2"});
+        Future<String> container1 = component.createContainerAsync("hello-world", null, new String[]{"ID=1"}, null);
+        Future<String> container2 = component.createContainerAsync("hello-world", null, new String[]{"ID=2"}, null);
         String containerId1 = container1.get();
         String containerId2 = container2.get();
         assertEquals("IDs of asynchronously created containers", "1;2", containerId1 + ";" + containerId2);

--- a/src/test/java/org/hobbit/core/components/ContainerCreationTest.java
+++ b/src/test/java/org/hobbit/core/components/ContainerCreationTest.java
@@ -1,0 +1,136 @@
+/**
+ * This file is part of core.
+ *
+ * core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.hobbit.core.components;
+
+import org.hobbit.core.components.dummy.DummyComponentExecutor;
+import java.util.Random;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.MessageProperties;
+import org.hobbit.core.rabbit.RabbitMQUtils;
+import java.io.IOException;
+import org.hobbit.core.Commands;
+import org.hobbit.core.components.dummy.AbstractDummyPlatformController;
+import org.hobbit.core.data.StartCommandData;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.hobbit.core.components.dummy.DummyCommandReceivingComponent;
+import org.hobbit.core.Constants;
+import org.hobbit.core.TestConstants;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.Test;
+import org.junit.Rule;
+import org.junit.rules.Stopwatch;
+import static org.junit.Assert.*;
+
+
+public class ContainerCreationTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ContainerCreationTest.class);
+
+    private DummyPlatformController platformController = null;
+
+    private static final String HOBBIT_SESSION_ID = "123";
+    private static final long CONTAINER_CREATION_DELAY = 2000;
+
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+    private AbstractCommandReceivingComponent component;
+
+    @Rule
+    public Stopwatch stopwatch = new Stopwatch() {};
+
+    @Before
+    public void setUp() throws Exception {
+        environmentVariables.set(Constants.RABBIT_MQ_HOST_NAME_KEY, TestConstants.RABBIT_HOST);
+        environmentVariables.set(Constants.HOBBIT_SESSION_ID_KEY, "0");
+
+        platformController = new DummyPlatformController(HOBBIT_SESSION_ID);
+        DummyComponentExecutor platformExecutor = new DummyComponentExecutor(platformController);
+        Thread platformThread = new Thread(platformExecutor);
+        platformThread.start();
+        platformController.waitForControllerBeingReady();
+
+        component = new DummyCommandReceivingComponent();
+        component.init();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        component.close();
+        platformController.terminate();
+    }
+
+    @Test(timeout = (long)(CONTAINER_CREATION_DELAY * 2.5))
+    public void testSync() throws Exception {
+        String containerId1 = component.createContainer("hello-world", null, new String[]{"ID=1", "DELAY="+CONTAINER_CREATION_DELAY});
+        String containerId2 = component.createContainer("hello-world", null, new String[]{"ID=2", "DELAY="+CONTAINER_CREATION_DELAY});
+        assertEquals("ID of synchronously created container", "1", containerId1);
+        assertEquals("ID of synchronously created container", "2", containerId2);
+        assertTrue("Spent at least linearly scaled delay while creating containers",
+                stopwatch.runtime(TimeUnit.MILLISECONDS) > CONTAINER_CREATION_DELAY * 2);
+    }
+
+    @Test(timeout = (long)(CONTAINER_CREATION_DELAY * 1.5))
+    public void testAsync() throws Exception {
+        Future<String> container1 = component.createContainerAsync("hello-world", null, new String[]{"ID=1", "DELAY="+CONTAINER_CREATION_DELAY});
+        Future<String> container2 = component.createContainerAsync("hello-world", null, new String[]{"ID=2", "DELAY="+CONTAINER_CREATION_DELAY});
+        Future<String> container3 = component.createContainerAsync("hello-world", null, new String[]{"ID=3", "DELAY=0"});
+        assertFalse("Asynchronously creating a container should take some time", container1.isDone());
+        assertFalse("Asynchronously creating a container should take some time", container2.isDone());
+        // (Third container is created without any delays.)
+        String containerId1 = container1.get();
+        String containerId2 = container2.get();
+        String containerId3 = container3.get();
+        assertEquals("IDs of asynchronously created containers", "1;2;3", containerId1 + ";" + containerId2 + ";" + containerId3);
+    }
+
+    protected static class DummyPlatformController extends AbstractDummyPlatformController {
+        public DummyPlatformController(String sessionId) {
+            super(true);
+            addCommandHeaderId(sessionId);
+        }
+
+        public void receiveCommand(byte command, byte[] data, String sessionId, AMQP.BasicProperties props) {
+            if (command == Commands.DOCKER_CONTAINER_START) {
+                String[] envVars = gson.fromJson(RabbitMQUtils.readString(data), StartCommandData.class).getEnvironmentVariables();
+                String containerId = Stream.of(envVars).filter(kv -> kv.startsWith("ID=")).findAny().get().split("=", 2)[1];
+                long delay = Long.parseLong(Stream.of(envVars).filter(kv -> kv.startsWith("DELAY=")).findAny().get().split("=", 2)[1]);
+                LOGGER.info("Creating container {} with delay {}...", containerId, delay);
+
+                try {
+                    Thread.sleep(delay);
+
+                    AMQP.BasicProperties.Builder propsBuilder = new AMQP.BasicProperties.Builder();
+                    propsBuilder.deliveryMode(2);
+                    propsBuilder.correlationId(props.getCorrelationId());
+                    AMQP.BasicProperties replyProps = propsBuilder.build();
+
+                    cmdChannel.basicPublish("", props.getReplyTo(), replyProps,
+                            RabbitMQUtils.writeString(containerId));
+                } catch (IOException | InterruptedException e) {
+                    LOGGER.error("Exception in receiveCommand", e);
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/org/hobbit/core/components/ContainerCreationTest.java
+++ b/src/test/java/org/hobbit/core/components/ContainerCreationTest.java
@@ -92,9 +92,9 @@ public class ContainerCreationTest {
 
     @Test(timeout = (long)(CONTAINER_CREATION_DELAY * 1.5))
     public void testAsync() throws Exception {
-        Future<String> container1 = component.createContainerAsync("hello-world", null, new String[]{"ID=1", "DELAY="+CONTAINER_CREATION_DELAY});
-        Future<String> container2 = component.createContainerAsync("hello-world", null, new String[]{"ID=2", "DELAY="+CONTAINER_CREATION_DELAY});
-        Future<String> container3 = component.createContainerAsync("hello-world", null, new String[]{"ID=3", "DELAY=0"});
+        Future<String> container1 = component.createContainerAsync("hello-world", null, new String[]{"ID=1", "DELAY="+CONTAINER_CREATION_DELAY}, null);
+        Future<String> container2 = component.createContainerAsync("hello-world", null, new String[]{"ID=2", "DELAY="+CONTAINER_CREATION_DELAY}, null);
+        Future<String> container3 = component.createContainerAsync("hello-world", null, new String[]{"ID=3", "DELAY=0"}, null);
         assertFalse("Asynchronously creating a container should take some time", container1.isDone());
         assertFalse("Asynchronously creating a container should take some time", container2.isDone());
         // (Third container is created without any delays.)

--- a/src/test/java/org/hobbit/core/components/ContainerEnvironmentTest.java
+++ b/src/test/java/org/hobbit/core/components/ContainerEnvironmentTest.java
@@ -1,0 +1,129 @@
+/**
+ * This file is part of core.
+ *
+ * core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.hobbit.core.components;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.hobbit.core.components.dummy.DummyCommandReceivingComponent;
+import org.hobbit.core.Constants;
+import org.hobbit.core.TestConstants;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+
+@RunWith(Parameterized.class)
+public class ContainerEnvironmentTest {
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+    private AbstractCommandReceivingComponent component;
+
+    @Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            {
+                // input
+                null,
+                // expected output
+                new String[] {
+                    Constants.RABBIT_MQ_HOST_NAME_KEY + "=" + TestConstants.RABBIT_HOST,
+                    Constants.HOBBIT_SESSION_ID_KEY + "=0",
+                }
+            },
+            {
+                // input
+                new String[] {},
+                // expected output
+                new String[] {
+                    Constants.RABBIT_MQ_HOST_NAME_KEY + "=" + TestConstants.RABBIT_HOST,
+                    Constants.HOBBIT_SESSION_ID_KEY + "=0",
+                }
+            },
+            {
+                // input
+                new String[] {
+                    "A=B",
+                    "C=",
+                },
+                // expected output
+                new String[] {
+                    "A=B",
+                    "C=",
+                    Constants.RABBIT_MQ_HOST_NAME_KEY + "=" + TestConstants.RABBIT_HOST,
+                    Constants.HOBBIT_SESSION_ID_KEY + "=0",
+                }
+            },
+            {
+                // input
+                new String[] {
+                    Constants.RABBIT_MQ_HOST_NAME_KEY + "=another.rabbit",
+                },
+                // expected output
+                new String[] {
+                    Constants.RABBIT_MQ_HOST_NAME_KEY + "=another.rabbit",
+                    Constants.HOBBIT_SESSION_ID_KEY + "=0",
+                }
+            },
+            {
+                // input
+                new String[] {
+                    "A=B",
+                    Constants.RABBIT_MQ_HOST_NAME_KEY + "=another.rabbit",
+                    "C=",
+                },
+                // expected output
+                new String[] {
+                    "A=B",
+                    Constants.RABBIT_MQ_HOST_NAME_KEY + "=another.rabbit",
+                    "C=",
+                    Constants.HOBBIT_SESSION_ID_KEY + "=0",
+                }
+            },
+        });
+    }
+
+    @Parameter(0)
+    public String[] passedEnvVariables;
+
+    @Parameter(1)
+    public String[] expectedEnvVariables;
+
+    @Before
+    public void setUp() throws Exception {
+        environmentVariables.set(Constants.RABBIT_MQ_HOST_NAME_KEY, TestConstants.RABBIT_HOST);
+        environmentVariables.set(Constants.HOBBIT_SESSION_ID_KEY, "0");
+
+        component = new DummyCommandReceivingComponent();
+        component.init();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        component.close();
+    }
+
+    @Test
+    public void test() throws Exception {
+        assertArrayEquals(expectedEnvVariables, component.extendContainerEnvVariables(passedEnvVariables));
+    }
+}

--- a/src/test/java/org/hobbit/core/components/EvaluationModuleTest.java
+++ b/src/test/java/org/hobbit/core/components/EvaluationModuleTest.java
@@ -35,6 +35,7 @@ import org.hobbit.core.components.test.InMemoryEvaluationStore;
 import org.hobbit.core.components.test.InMemoryEvaluationStore.ResultImpl;
 import org.hobbit.core.components.test.InMemoryEvaluationStore.ResultPairImpl;
 import org.hobbit.core.rabbit.RabbitMQUtils;
+import org.hobbit.vocab.HobbitExperiments;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -69,7 +70,7 @@ public class EvaluationModuleTest extends AbstractEvaluationModule {
     public void test() throws Exception {
         environmentVariables.set(Constants.RABBIT_MQ_HOST_NAME_KEY, TestConstants.RABBIT_HOST);
         environmentVariables.set(Constants.HOBBIT_SESSION_ID_KEY, "0");
-        environmentVariables.set(Constants.HOBBIT_EXPERIMENT_URI_KEY, Constants.EXPERIMENT_URI_NS + "123");
+        environmentVariables.set(Constants.HOBBIT_EXPERIMENT_URI_KEY, HobbitExperiments.getExperimentURI("123"));
 
         // Create the eval store and add some data
         InMemoryEvaluationStore evalStore = new InMemoryEvaluationStore();

--- a/src/test/java/org/hobbit/core/components/dummy/AbstractDummyPlatformController.java
+++ b/src/test/java/org/hobbit/core/components/dummy/AbstractDummyPlatformController.java
@@ -1,0 +1,94 @@
+/**
+ * This file is part of core.
+ *
+ * core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.hobbit.core.components.dummy;
+
+import org.hobbit.core.Constants;
+import org.hobbit.core.rabbit.RabbitMQUtils;
+import java.io.IOException;
+import com.rabbitmq.client.AMQP.BasicProperties;
+import org.apache.commons.io.Charsets;
+import java.nio.ByteBuffer;
+import java.util.concurrent.Semaphore;
+import org.hobbit.core.components.AbstractCommandReceivingComponent;
+
+import org.junit.Ignore;
+
+@Ignore
+public abstract class AbstractDummyPlatformController extends AbstractCommandReceivingComponent {
+    private boolean readyFlag = false;
+    private Semaphore terminationMutex = new Semaphore(0);
+
+    @Override
+    public void run() throws Exception {
+        readyFlag = true;
+        terminationMutex.acquire();
+    }
+
+    public void waitForControllerBeingReady() throws InterruptedException {
+        while (!readyFlag) {
+            Thread.sleep(500);
+        }
+    }
+
+    @Override
+    protected void handleCmd(byte bytes[], String replyTo) {
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        int idLength = buffer.getInt();
+        byte sessionIdBytes[] = new byte[idLength];
+        buffer.get(sessionIdBytes);
+        String sessionId = new String(sessionIdBytes, Charsets.UTF_8);
+        byte command = buffer.get();
+        byte remainingData[];
+        if (buffer.remaining() > 0) {
+            remainingData = new byte[buffer.remaining()];
+            buffer.get(remainingData);
+        } else {
+            remainingData = new byte[0];
+        }
+        receiveCommand(command, remainingData, sessionId, replyTo);
+    }
+
+    public void sendToCmdQueue(String address, byte command, byte data[], BasicProperties props)
+            throws IOException {
+        byte sessionIdBytes[] = RabbitMQUtils.writeString(address);
+        // + 5 because 4 bytes for the session ID length and 1 byte for the
+        // command
+        int dataLength = sessionIdBytes.length + 5;
+        boolean attachData = (data != null) && (data.length > 0);
+        if (attachData) {
+            dataLength += data.length;
+        }
+        ByteBuffer buffer = ByteBuffer.allocate(dataLength);
+        buffer.putInt(sessionIdBytes.length);
+        buffer.put(sessionIdBytes);
+        buffer.put(command);
+        if (attachData) {
+            buffer.put(data);
+        }
+        cmdChannel.basicPublish(Constants.HOBBIT_COMMAND_EXCHANGE_NAME, "", props, buffer.array());
+    }
+
+    @Override
+    public void receiveCommand(byte command, byte[] data) {
+    }
+
+    public abstract void receiveCommand(byte command, byte[] data, String sessionId, String replyTo);
+
+    public void terminate() {
+        terminationMutex.release();
+    }
+}

--- a/src/test/java/org/hobbit/core/components/dummy/AbstractDummyPlatformController.java
+++ b/src/test/java/org/hobbit/core/components/dummy/AbstractDummyPlatformController.java
@@ -19,6 +19,8 @@ package org.hobbit.core.components.dummy;
 import org.hobbit.core.Constants;
 import org.hobbit.core.rabbit.RabbitMQUtils;
 import java.io.IOException;
+
+import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.AMQP.BasicProperties;
 import org.apache.commons.io.Charsets;
 import java.nio.ByteBuffer;
@@ -31,6 +33,14 @@ import org.junit.Ignore;
 public abstract class AbstractDummyPlatformController extends AbstractCommandReceivingComponent {
     private boolean readyFlag = false;
     private Semaphore terminationMutex = new Semaphore(0);
+
+    public AbstractDummyPlatformController() {
+        super();
+    }
+
+    public AbstractDummyPlatformController(boolean execCommandsInParallel) {
+        super(execCommandsInParallel);
+    }
 
     @Override
     public void run() throws Exception {
@@ -45,7 +55,7 @@ public abstract class AbstractDummyPlatformController extends AbstractCommandRec
     }
 
     @Override
-    protected void handleCmd(byte bytes[], String replyTo) {
+    protected void handleCmd(byte bytes[], AMQP.BasicProperties props) {
         ByteBuffer buffer = ByteBuffer.wrap(bytes);
         int idLength = buffer.getInt();
         byte sessionIdBytes[] = new byte[idLength];
@@ -59,7 +69,7 @@ public abstract class AbstractDummyPlatformController extends AbstractCommandRec
         } else {
             remainingData = new byte[0];
         }
-        receiveCommand(command, remainingData, sessionId, replyTo);
+        receiveCommand(command, remainingData, sessionId, props);
     }
 
     public void sendToCmdQueue(String address, byte command, byte data[], BasicProperties props)
@@ -86,7 +96,7 @@ public abstract class AbstractDummyPlatformController extends AbstractCommandRec
     public void receiveCommand(byte command, byte[] data) {
     }
 
-    public abstract void receiveCommand(byte command, byte[] data, String sessionId, String replyTo);
+    public abstract void receiveCommand(byte command, byte[] data, String sessionId, AMQP.BasicProperties props);
 
     public void terminate() {
         terminationMutex.release();

--- a/src/test/java/org/hobbit/core/components/dummy/DummyCommandReceivingComponent.java
+++ b/src/test/java/org/hobbit/core/components/dummy/DummyCommandReceivingComponent.java
@@ -1,0 +1,32 @@
+/**
+ * This file is part of core.
+ *
+ * core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.hobbit.core.components.dummy;
+
+import org.hobbit.core.components.AbstractCommandReceivingComponent;
+
+import org.junit.Ignore;
+
+@Ignore
+public class DummyCommandReceivingComponent extends AbstractCommandReceivingComponent {
+    @Override
+    public void run() {
+    }
+
+    @Override
+    public void receiveCommand(byte command, byte[] data) {
+    }
+}

--- a/src/test/java/org/hobbit/core/mimic/DockerBasedMimickingAlgTest.java
+++ b/src/test/java/org/hobbit/core/mimic/DockerBasedMimickingAlgTest.java
@@ -5,21 +5,18 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
-import java.util.concurrent.Semaphore;
 
-import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.hobbit.core.Commands;
 import org.hobbit.core.Constants;
 import org.hobbit.core.TestConstants;
-import org.hobbit.core.components.AbstractCommandReceivingComponent;
 import org.hobbit.core.components.AbstractComponent;
 import org.hobbit.core.components.AbstractPlatformConnectorComponent;
+import org.hobbit.core.components.dummy.AbstractDummyPlatformController;
 import org.hobbit.core.components.dummy.DummyComponentExecutor;
 import org.hobbit.core.data.StartCommandData;
 import org.hobbit.core.rabbit.RabbitMQUtils;
@@ -32,7 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
-import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.MessageProperties;
 
 /**
@@ -107,36 +103,16 @@ public class DockerBasedMimickingAlgTest extends AbstractPlatformConnectorCompon
         return temp;
     }
 
-    protected static class DummyPlatformController extends AbstractCommandReceivingComponent {
+    protected static class DummyPlatformController extends AbstractDummyPlatformController {
 
         public DummyComponentExecutor mimickingExecutor;
         public Thread mimickingThread;
         public Random random = new Random();
-        private boolean readyFlag = false;
         private Gson gson = new Gson();
-
-        private Semaphore terminationMutex = new Semaphore(0);
 
         public DummyPlatformController(String sessionId) {
             super();
             addCommandHeaderId(sessionId);
-        }
-
-        protected void handleCmd(byte bytes[], String replyTo) {
-            ByteBuffer buffer = ByteBuffer.wrap(bytes);
-            int idLength = buffer.getInt();
-            byte sessionIdBytes[] = new byte[idLength];
-            buffer.get(sessionIdBytes);
-            String sessionId = new String(sessionIdBytes, Charsets.UTF_8);
-            byte command = buffer.get();
-            byte remainingData[];
-            if (buffer.remaining() > 0) {
-                remainingData = new byte[buffer.remaining()];
-                buffer.get(remainingData);
-            } else {
-                remainingData = new byte[0];
-            }
-            receiveCommand(command, remainingData, sessionId, replyTo);
         }
 
         public void receiveCommand(byte command, byte[] data, String sessionId, String replyTo) {
@@ -181,46 +157,6 @@ public class DockerBasedMimickingAlgTest extends AbstractPlatformConnectorCompon
                     LOGGER.error("Exception while trying to respond to a container creation command.", e);
                 }
             }
-        }
-
-        public void waitForControllerBeingReady() throws InterruptedException {
-            while (!readyFlag) {
-                Thread.sleep(500);
-            }
-        }
-
-        public void sendToCmdQueue(String address, byte command, byte data[], BasicProperties props)
-                throws IOException {
-            byte sessionIdBytes[] = RabbitMQUtils.writeString(address);
-            // + 5 because 4 bytes for the session ID length and 1 byte for the
-            // command
-            int dataLength = sessionIdBytes.length + 5;
-            boolean attachData = (data != null) && (data.length > 0);
-            if (attachData) {
-                dataLength += data.length;
-            }
-            ByteBuffer buffer = ByteBuffer.allocate(dataLength);
-            buffer.putInt(sessionIdBytes.length);
-            buffer.put(sessionIdBytes);
-            buffer.put(command);
-            if (attachData) {
-                buffer.put(data);
-            }
-            cmdChannel.basicPublish(Constants.HOBBIT_COMMAND_EXCHANGE_NAME, "", props, buffer.array());
-        }
-
-        @Override
-        public void receiveCommand(byte command, byte[] data) {
-        }
-
-        @Override
-        public void run() throws Exception {
-            readyFlag = true;
-            terminationMutex.acquire();
-        }
-
-        public void terminate() {
-            terminationMutex.release();
         }
     }
 


### PR DESCRIPTION
- fix generator IDs when `createGenerator` is used multiple times
- fix a benchmark workflow without evaluation storage
- allow to override RabbitMQ address when creating a container
- add asynchronous container creation API and command processing