### PR TITLE
RabbitMQ version update from 4.8.0 to 5.7.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>com.rabbitmq</groupId>
             <artifactId>amqp-client</artifactId>
-            <version>4.8.0</version>
+            <version>5.7.3</version>
         </dependency>
         <!-- Jena -->
         <dependency>

--- a/src/main/java/org/hobbit/core/components/AbstractEvaluationModule.java
+++ b/src/main/java/org/hobbit/core/components/AbstractEvaluationModule.java
@@ -19,7 +19,6 @@ package org.hobbit.core.components;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.IOUtils;
@@ -37,10 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.rabbitmq.client.AMQP.BasicProperties;
-import com.rabbitmq.client.AMQP;
-import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.Delivery;
-import com.rabbitmq.client.Envelope;
 
 /**
  * This abstract class implements basic functions that can be used to implement
@@ -69,7 +65,6 @@ public abstract class AbstractEvaluationModule extends AbstractPlatformConnector
      * The URI of the experiment.
      */
     protected String experimentUri;
-    
 
     public AbstractEvaluationModule() {
         defaultContainerType = Constants.CONTAINER_TYPE_BENCHMARK;
@@ -120,39 +115,33 @@ public abstract class AbstractEvaluationModule extends AbstractPlatformConnector
 
         while (true) {
             // request next response pair
-        	Delivery delivery=null;
             props = new BasicProperties.Builder().deliveryMode(2).replyTo(evalStore2EvalModuleQueue.name).build();
             evalModule2EvalStoreQueue.channel.basicPublish("", evalModule2EvalStoreQueue.name, props, requestBody);
-            delivery = consumer.deliveryQueue.poll(300,TimeUnit.MILLISECONDS);
-            //if(!deliveryQueue.isEmpty()) {
-            	 
-            	 // parse the response
-                 buffer = ByteBuffer.wrap(delivery.getBody());
-                 // if the response is empty
-                 if (buffer.remaining() == 0) {
-                     LOGGER.error("Got a completely empty response from the evaluation storage.");
-                     return;
-                 }
-                 requestBody[0] = buffer.get();
-
-                 // if the response is empty
-                 if (buffer.remaining() == 0) {
-                     return;
-                 }
-                 byte[] data = RabbitMQUtils.readByteArray(buffer);
-                 taskSentTimestamp = data.length > 0 ? RabbitMQUtils.readLong(data) : 0;
-                 expectedData = RabbitMQUtils.readByteArray(buffer);
-
-                 data = RabbitMQUtils.readByteArray(buffer);
-                 responseReceivedTimestamp = data.length > 0 ? RabbitMQUtils.readLong(data) : 0;
-                 receivedData = RabbitMQUtils.readByteArray(buffer);
-
-                 evaluateResponse(expectedData, receivedData, taskSentTimestamp, responseReceivedTimestamp);
-
+            Delivery delivery = consumer.getDeliveryQueue().poll(300, TimeUnit.MILLISECONDS);
+            // parse the response
+            buffer = ByteBuffer.wrap(delivery.getBody());
+            // if the response is empty
+            if (buffer.remaining() == 0) {
+                LOGGER.error("Got a completely empty response from the evaluation storage.");
+                return;
             }
-            
-                   }
-    //}
+            requestBody[0] = buffer.get();
+
+            // if the response is empty
+            if (buffer.remaining() == 0) {
+                return;
+            }
+            byte[] data = RabbitMQUtils.readByteArray(buffer);
+            taskSentTimestamp = data.length > 0 ? RabbitMQUtils.readLong(data) : 0;
+            expectedData = RabbitMQUtils.readByteArray(buffer);
+
+            data = RabbitMQUtils.readByteArray(buffer);
+            responseReceivedTimestamp = data.length > 0 ? RabbitMQUtils.readLong(data) : 0;
+            receivedData = RabbitMQUtils.readByteArray(buffer);
+
+            evaluateResponse(expectedData, receivedData, taskSentTimestamp, responseReceivedTimestamp);
+        }
+    }
 
     /**
      * Evaluates the given response pair.

--- a/src/main/java/org/hobbit/core/components/AbstractEvaluationModule.java
+++ b/src/main/java/org/hobbit/core/components/AbstractEvaluationModule.java
@@ -19,6 +19,8 @@ package org.hobbit.core.components;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.jena.rdf.model.Model;
@@ -27,6 +29,7 @@ import org.apache.jena.vocabulary.RDF;
 import org.hobbit.core.Commands;
 import org.hobbit.core.Constants;
 import org.hobbit.core.data.RabbitQueue;
+import org.hobbit.core.rabbit.CustomConsumer;
 import org.hobbit.core.rabbit.RabbitMQUtils;
 import org.hobbit.utils.EnvVariables;
 import org.hobbit.vocab.HOBBIT;
@@ -34,7 +37,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.rabbitmq.client.AMQP.BasicProperties;
-import com.rabbitmq.client.QueueingConsumer;
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.DefaultConsumer;
+import com.rabbitmq.client.Delivery;
+import com.rabbitmq.client.Envelope;
 
 /**
  * This abstract class implements basic functions that can be used to implement
@@ -50,7 +56,7 @@ public abstract class AbstractEvaluationModule extends AbstractPlatformConnector
     /**
      * Consumer used to receive the responses from the evaluation storage.
      */
-    protected QueueingConsumer consumer;
+    protected CustomConsumer consumer;
     /**
      * Queue to the evaluation storage.
      */
@@ -63,6 +69,7 @@ public abstract class AbstractEvaluationModule extends AbstractPlatformConnector
      * The URI of the experiment.
      */
     protected String experimentUri;
+    
 
     public AbstractEvaluationModule() {
         defaultContainerType = Constants.CONTAINER_TYPE_BENCHMARK;
@@ -80,7 +87,7 @@ public abstract class AbstractEvaluationModule extends AbstractPlatformConnector
         evalStore2EvalModuleQueue = getFactoryForIncomingDataQueues()
                 .createDefaultRabbitQueue(generateSessionQueueName(Constants.EVAL_STORAGE_2_EVAL_MODULE_DEFAULT_QUEUE_NAME));
 
-        consumer = new QueueingConsumer(evalStore2EvalModuleQueue.channel);
+        consumer = new CustomConsumer(evalStore2EvalModuleQueue.channel);
         evalStore2EvalModuleQueue.channel.basicConsume(evalStore2EvalModuleQueue.name, consumer);
     }
 
@@ -113,33 +120,39 @@ public abstract class AbstractEvaluationModule extends AbstractPlatformConnector
 
         while (true) {
             // request next response pair
+        	Delivery delivery=null;
             props = new BasicProperties.Builder().deliveryMode(2).replyTo(evalStore2EvalModuleQueue.name).build();
             evalModule2EvalStoreQueue.channel.basicPublish("", evalModule2EvalStoreQueue.name, props, requestBody);
-            QueueingConsumer.Delivery delivery = consumer.nextDelivery();
-            // parse the response
-            buffer = ByteBuffer.wrap(delivery.getBody());
-            // if the response is empty
-            if (buffer.remaining() == 0) {
-                LOGGER.error("Got a completely empty response from the evaluation storage.");
-                return;
+            delivery = consumer.deliveryQueue.poll(300,TimeUnit.MILLISECONDS);
+            //if(!deliveryQueue.isEmpty()) {
+            	 
+            	 // parse the response
+                 buffer = ByteBuffer.wrap(delivery.getBody());
+                 // if the response is empty
+                 if (buffer.remaining() == 0) {
+                     LOGGER.error("Got a completely empty response from the evaluation storage.");
+                     return;
+                 }
+                 requestBody[0] = buffer.get();
+
+                 // if the response is empty
+                 if (buffer.remaining() == 0) {
+                     return;
+                 }
+                 byte[] data = RabbitMQUtils.readByteArray(buffer);
+                 taskSentTimestamp = data.length > 0 ? RabbitMQUtils.readLong(data) : 0;
+                 expectedData = RabbitMQUtils.readByteArray(buffer);
+
+                 data = RabbitMQUtils.readByteArray(buffer);
+                 responseReceivedTimestamp = data.length > 0 ? RabbitMQUtils.readLong(data) : 0;
+                 receivedData = RabbitMQUtils.readByteArray(buffer);
+
+                 evaluateResponse(expectedData, receivedData, taskSentTimestamp, responseReceivedTimestamp);
+
             }
-            requestBody[0] = buffer.get();
-
-            // if the response is empty
-            if (buffer.remaining() == 0) {
-                return;
-            }
-            byte[] data = RabbitMQUtils.readByteArray(buffer);
-            taskSentTimestamp = data.length > 0 ? RabbitMQUtils.readLong(data) : 0;
-            expectedData = RabbitMQUtils.readByteArray(buffer);
-
-            data = RabbitMQUtils.readByteArray(buffer);
-            responseReceivedTimestamp = data.length > 0 ? RabbitMQUtils.readLong(data) : 0;
-            receivedData = RabbitMQUtils.readByteArray(buffer);
-
-            evaluateResponse(expectedData, receivedData, taskSentTimestamp, responseReceivedTimestamp);
-        }
-    }
+            
+                   }
+    //}
 
     /**
      * Evaluates the given response pair.

--- a/src/main/java/org/hobbit/core/components/AbstractEvaluationModule.java
+++ b/src/main/java/org/hobbit/core/components/AbstractEvaluationModule.java
@@ -20,7 +20,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -124,8 +123,12 @@ public abstract class AbstractEvaluationModule extends AbstractPlatformConnector
             //Wait for delivery message
             Delivery delivery = consumer.getDeliveryQueue().poll(QUEUEPOLLTIMEOUT, TimeUnit.MILLISECONDS);
             // parse the response
-            try
+            if (delivery == null)
             {
+            	LOGGER.error("No Message Received after waiting for ten minutes");
+            	return;
+            }
+
             	buffer = ByteBuffer.wrap(delivery.getBody());
             
             
@@ -151,11 +154,7 @@ public abstract class AbstractEvaluationModule extends AbstractPlatformConnector
 
 
             evaluateResponse(expectedData, receivedData, taskSentTimestamp, responseReceivedTimestamp);
-            }catch(NullPointerException e) 
             
-            {
-            	LOGGER.error("No Message Received after waiting for ten minutes");
-            }
         }
     }
 

--- a/src/main/java/org/hobbit/core/components/AbstractTaskGenerator.java
+++ b/src/main/java/org/hobbit/core/components/AbstractTaskGenerator.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Semaphore;
 import org.apache.commons.io.IOUtils;
 import org.hobbit.core.Commands;
 import org.hobbit.core.Constants;
+import org.hobbit.core.rabbit.CustomConsumer;
 import org.hobbit.core.rabbit.DataHandler;
 import org.hobbit.core.rabbit.DataReceiver;
 import org.hobbit.core.rabbit.DataReceiverImpl;
@@ -32,7 +33,6 @@ import org.hobbit.utils.EnvVariables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.rabbitmq.client.QueueingConsumer;
 
 /**
  * This abstract class implements basic functions that can be used to implement
@@ -89,7 +89,7 @@ public abstract class AbstractTaskGenerator extends AbstractPlatformConnectorCom
     protected DataSender sender2EvalStore;
     protected DataReceiver dataGenReceiver;
 
-    protected QueueingConsumer consumer;
+    protected CustomConsumer consumer;
     protected boolean runFlag;
 
     /**

--- a/src/main/java/org/hobbit/core/components/AbstractTaskGenerator.java
+++ b/src/main/java/org/hobbit/core/components/AbstractTaskGenerator.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Semaphore;
 import org.apache.commons.io.IOUtils;
 import org.hobbit.core.Commands;
 import org.hobbit.core.Constants;
-import org.hobbit.core.rabbit.CustomConsumer;
+import org.hobbit.core.rabbit.QueueingConsumer;
 import org.hobbit.core.rabbit.DataHandler;
 import org.hobbit.core.rabbit.DataReceiver;
 import org.hobbit.core.rabbit.DataReceiverImpl;
@@ -88,8 +88,8 @@ public abstract class AbstractTaskGenerator extends AbstractPlatformConnectorCom
     protected DataSender sender2System;
     protected DataSender sender2EvalStore;
     protected DataReceiver dataGenReceiver;
-
-    protected CustomConsumer consumer;
+    @Deprecated
+    protected QueueingConsumer consumer;
     protected boolean runFlag;
 
     /**

--- a/src/main/java/org/hobbit/core/components/utils/SystemResourceUsageRequester.java
+++ b/src/main/java/org/hobbit/core/components/utils/SystemResourceUsageRequester.java
@@ -4,6 +4,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.Charsets;
 import org.hobbit.core.Commands;
@@ -11,6 +12,7 @@ import org.hobbit.core.Constants;
 import org.hobbit.core.components.AbstractCommandReceivingComponent;
 import org.hobbit.core.components.PlatformConnector;
 import org.hobbit.core.data.usage.ResourceUsageInformation;
+import org.hobbit.core.rabbit.CustomConsumer;
 import org.hobbit.core.rabbit.RabbitMQUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,7 +20,7 @@ import org.slf4j.LoggerFactory;
 import com.google.gson.Gson;
 import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.Channel;
-import com.rabbitmq.client.QueueingConsumer;
+import com.rabbitmq.client.Delivery;
 
 public class SystemResourceUsageRequester implements Closeable {
 
@@ -32,10 +34,7 @@ public class SystemResourceUsageRequester implements Closeable {
             // if (responseQueueName == null) {
             responseQueueName = incomingChannel.queueDeclare().getQueue();
             // }
-            QueueingConsumer responseConsumer = new QueueingConsumer(cmdChannel);
-            incomingChannel.basicConsume(responseQueueName, responseConsumer);
-            return new SystemResourceUsageRequester(cmdChannel, incomingChannel, responseQueueName, responseConsumer,
-                    sessionId);
+            return new SystemResourceUsageRequester(cmdChannel, incomingChannel, responseQueueName, sessionId);
         } catch (Exception e) {
             LOGGER.error("Exception while creating SystemResourceUsageRequester. Returning null.", e);
         }
@@ -51,7 +50,7 @@ public class SystemResourceUsageRequester implements Closeable {
      * Consumer of the queue that is used to receive responses for messages that are
      * sent via the command queue and for which an answer is expected.
      */
-    private QueueingConsumer responseConsumer = null;
+    private CustomConsumer responseConsumer = null;
     /**
      * Channel that is used for the command queue but not owned by this class (i.e.,
      * it won't be closed).
@@ -65,7 +64,9 @@ public class SystemResourceUsageRequester implements Closeable {
     protected Gson gson = new Gson();
 
     protected SystemResourceUsageRequester(Channel cmdChannel, Channel incomingChannel, String responseQueueName,
-            QueueingConsumer responseConsumer, String sessionId) {
+            String sessionId) throws IOException {
+    	CustomConsumer responseConsumer = new CustomConsumer(cmdChannel);
+    	incomingChannel.basicConsume(responseQueueName, responseConsumer);
         this.cmdChannel = cmdChannel;
         this.incomingChannel = incomingChannel;
         this.responseQueueName = responseQueueName;
@@ -77,8 +78,8 @@ public class SystemResourceUsageRequester implements Closeable {
         try {
             BasicProperties props = new BasicProperties.Builder().deliveryMode(2).replyTo(responseQueueName).build();
             sendToCmdQueue(Commands.REQUEST_SYSTEM_RESOURCES_USAGE, null, props);
-            QueueingConsumer.Delivery delivery = responseConsumer
-                    .nextDelivery(AbstractCommandReceivingComponent.DEFAULT_CMD_RESPONSE_TIMEOUT);
+            Delivery delivery = responseConsumer.getDeliveryQueue().poll(AbstractCommandReceivingComponent.DEFAULT_CMD_RESPONSE_TIMEOUT, 
+            		TimeUnit.MILLISECONDS);
             Objects.requireNonNull(delivery, "Didn't got a response for a create container message.");
             if (delivery.getBody().length > 0) {
                 return gson.fromJson(RabbitMQUtils.readString(delivery.getBody()), ResourceUsageInformation.class);

--- a/src/main/java/org/hobbit/core/rabbit/CustomConsumer.java
+++ b/src/main/java/org/hobbit/core/rabbit/CustomConsumer.java
@@ -2,17 +2,24 @@ package org.hobbit.core.rabbit;
 
 import java.io.IOException;
 import java.util.concurrent.LinkedBlockingQueue;
-
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.Delivery;
 import com.rabbitmq.client.Envelope;
+
 public class CustomConsumer extends DefaultConsumer {
     
-    public LinkedBlockingQueue<Delivery> deliveryQueue = new LinkedBlockingQueue<>();
+    private LinkedBlockingQueue<Delivery> deliveryQueue;
+    
+    
     public CustomConsumer(Channel channel) {
+    	this(channel, new LinkedBlockingQueue<Delivery>());
+    }
+    
+    public CustomConsumer(Channel channel, LinkedBlockingQueue<Delivery> deliveryQueue) {
         super(channel);
+        this.deliveryQueue = deliveryQueue;
     }
     @Override
    public void handleDelivery(String consumerTag,
@@ -23,4 +30,9 @@ public class CustomConsumer extends DefaultConsumer {
    {
         deliveryQueue.add(new Delivery(envelope,properties,body));
    }
+
+	public LinkedBlockingQueue<Delivery> getDeliveryQueue() {
+		return deliveryQueue;
+	}
+    
 }

--- a/src/main/java/org/hobbit/core/rabbit/CustomConsumer.java
+++ b/src/main/java/org/hobbit/core/rabbit/CustomConsumer.java
@@ -1,0 +1,26 @@
+package org.hobbit.core.rabbit;
+
+import java.io.IOException;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.DefaultConsumer;
+import com.rabbitmq.client.Delivery;
+import com.rabbitmq.client.Envelope;
+public class CustomConsumer extends DefaultConsumer {
+    
+    public LinkedBlockingQueue<Delivery> deliveryQueue = new LinkedBlockingQueue<>();
+    public CustomConsumer(Channel channel) {
+        super(channel);
+    }
+    @Override
+   public void handleDelivery(String consumerTag,
+                              Envelope envelope,
+                              AMQP.BasicProperties properties,
+                              byte[] body)
+       throws IOException
+   {
+        deliveryQueue.add(new Delivery(envelope,properties,body));
+   }
+}

--- a/src/main/java/org/hobbit/core/rabbit/DataReceiverImpl.java
+++ b/src/main/java/org/hobbit/core/rabbit/DataReceiverImpl.java
@@ -61,7 +61,7 @@ public class DataReceiverImpl implements DataReceiver {
             throws IOException {
         this.queue = queue;
         this.dataHandler = handler;
-        CustomConsumer consumer = new CustomConsumer(queue.channel);
+        QueueingConsumer consumer = new QueueingConsumer(queue.channel);
         queue.channel.basicConsume(queue.name, true, consumer);
         queue.channel.basicQos(maxParallelProcessedMsgs);
         executor = Executors.newFixedThreadPool(maxParallelProcessedMsgs);
@@ -143,7 +143,7 @@ public class DataReceiverImpl implements DataReceiver {
      * @return a Runnable instance that will handle incoming messages as soon as it
      *         will be executed
      */
-    protected TerminatableRunnable buildMsgReceivingTask(CustomConsumer consumer) {
+    protected TerminatableRunnable buildMsgReceivingTask(QueueingConsumer consumer) {
         return new MsgReceivingTask(consumer);
     }
 
@@ -161,11 +161,11 @@ public class DataReceiverImpl implements DataReceiver {
 
     protected class MsgReceivingTask implements TerminatableRunnable {
 
-        private CustomConsumer consumer;
+        private QueueingConsumer consumer;
         private boolean runFlag = true;
         private boolean terminatedFlag = false;
 
-        public MsgReceivingTask(CustomConsumer consumer) {
+        public MsgReceivingTask(QueueingConsumer consumer) {
             this.consumer = consumer;
         }
 

--- a/src/main/java/org/hobbit/core/rabbit/DataReceiverImpl.java
+++ b/src/main/java/org/hobbit/core/rabbit/DataReceiverImpl.java
@@ -11,8 +11,8 @@ import org.hobbit.utils.TerminatableRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.rabbitmq.client.QueueingConsumer;
-import com.rabbitmq.client.QueueingConsumer.Delivery;
+import com.rabbitmq.client.Delivery;
+
 
 /**
  * Implementation of the {@link DataReceiver} interface.
@@ -61,7 +61,7 @@ public class DataReceiverImpl implements DataReceiver {
             throws IOException {
         this.queue = queue;
         this.dataHandler = handler;
-        QueueingConsumer consumer = new QueueingConsumer(queue.channel);
+        CustomConsumer consumer = new CustomConsumer(queue.channel);
         queue.channel.basicConsume(queue.name, true, consumer);
         queue.channel.basicQos(maxParallelProcessedMsgs);
         executor = Executors.newFixedThreadPool(maxParallelProcessedMsgs);
@@ -143,7 +143,7 @@ public class DataReceiverImpl implements DataReceiver {
      * @return a Runnable instance that will handle incoming messages as soon as it
      *         will be executed
      */
-    protected TerminatableRunnable buildMsgReceivingTask(QueueingConsumer consumer) {
+    protected TerminatableRunnable buildMsgReceivingTask(CustomConsumer consumer) {
         return new MsgReceivingTask(consumer);
     }
 
@@ -161,11 +161,11 @@ public class DataReceiverImpl implements DataReceiver {
 
     protected class MsgReceivingTask implements TerminatableRunnable {
 
-        private QueueingConsumer consumer;
+        private CustomConsumer consumer;
         private boolean runFlag = true;
         private boolean terminatedFlag = false;
 
-        public MsgReceivingTask(QueueingConsumer consumer) {
+        public MsgReceivingTask(CustomConsumer consumer) {
             this.consumer = consumer;
         }
 
@@ -176,7 +176,7 @@ public class DataReceiverImpl implements DataReceiver {
             Delivery delivery = null;
             while (runFlag || (queue.messageCount() > 0) || (delivery != null)) {
                 try {
-                    delivery = consumer.nextDelivery(3000);
+                    delivery = consumer.getDeliveryQueue().poll(3000, TimeUnit.MILLISECONDS);
                 } catch (Exception e) {
                     LOGGER.error("Exception while waiting for delivery.", e);
                     increaseErrorCount();

--- a/src/main/java/org/hobbit/core/rabbit/QueueingConsumer.java
+++ b/src/main/java/org/hobbit/core/rabbit/QueueingConsumer.java
@@ -8,20 +8,32 @@ import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.Delivery;
 import com.rabbitmq.client.Envelope;
 
-public class CustomConsumer extends DefaultConsumer {
+/**
+ * This class extends the {@link DefaultConsumer} class 
+ * with blocking semantics. The class provides a linked blocking queue
+ * of {@link Delivery} class to fetch the next delivery message.
+ * 
+ * @author Altaf & Sourabh
+ *
+ */
+public class QueueingConsumer extends DefaultConsumer {
     
     private LinkedBlockingQueue<Delivery> deliveryQueue;
     
     
-    public CustomConsumer(Channel channel) {
+    public QueueingConsumer(Channel channel) {
     	this(channel, new LinkedBlockingQueue<Delivery>());
     }
     
-    public CustomConsumer(Channel channel, LinkedBlockingQueue<Delivery> deliveryQueue) {
+    public QueueingConsumer(Channel channel, LinkedBlockingQueue<Delivery> deliveryQueue) {
         super(channel);
         this.deliveryQueue = deliveryQueue;
     }
-    @Override
+    
+   /**
+    * Adds the delivery object to linked blocking queue for every receive
+    */
+   @Override
    public void handleDelivery(String consumerTag,
                               Envelope envelope,
                               AMQP.BasicProperties properties,

--- a/src/main/java/org/hobbit/core/rabbit/SimpleFileReceiver.java
+++ b/src/main/java/org/hobbit/core/rabbit/SimpleFileReceiver.java
@@ -50,26 +50,28 @@ public class SimpleFileReceiver {
 
     protected static final long DEFAULT_TIMEOUT = 1000;
 
+    protected QueueingConsumer consumer;
+    
     public static SimpleFileReceiver create(RabbitQueueFactory factory, String queueName) throws IOException {
         return create(factory.createDefaultRabbitQueue(queueName));
     }
 
     public static SimpleFileReceiver create(RabbitQueue queue) throws IOException {
-        CustomConsumer consumer = new CustomConsumer(queue.channel);
+        QueueingConsumer consumer = new QueueingConsumer(queue.channel);
         queue.channel.basicConsume(queue.name, true, consumer);
         queue.channel.basicQos(20);
         return new SimpleFileReceiver(queue, consumer);
     }
 
     protected RabbitQueue queue;
-    protected CustomConsumer consumer;
+    
     protected Map<String, FileReceiveState> fileStates = new HashMap<>();
     protected boolean terminated = false;
     protected int errorCount = 0;
     protected ExecutorService executor = Executors.newCachedThreadPool();
     protected long waitingForMsgTimeout = DEFAULT_TIMEOUT;
 
-    protected SimpleFileReceiver(RabbitQueue queue, CustomConsumer consumer) {
+    protected SimpleFileReceiver(RabbitQueue queue, QueueingConsumer consumer) {
         this.queue = queue;
         this.consumer = consumer;
     }

--- a/src/test/java/org/hobbit/core/rabbit/SenderReceiverTest.java
+++ b/src/test/java/org/hobbit/core/rabbit/SenderReceiverTest.java
@@ -213,7 +213,7 @@ public class SenderReceiverTest {
 
         @SuppressWarnings("unused")
         private void receiveMsgsSequentielly(RabbitQueue queue) throws Exception {
-            CustomConsumer consumer = new CustomConsumer(queue.channel);
+        	QueueingConsumer consumer = new QueueingConsumer(queue.channel);
             queue.channel.basicConsume(queue.name, true, consumer);
             Delivery delivery = null;
             while ((terminationMutex.availablePermits() == 0) || (queue.messageCount() > 0) || (delivery != null)) {
@@ -226,7 +226,7 @@ public class SenderReceiverTest {
 
         @SuppressWarnings("unused")
         private void receiveMsgsInParallel(RabbitQueue queue, ExecutorService executor) throws Exception {
-        	CustomConsumer consumer = new CustomConsumer(queue.channel);
+        	QueueingConsumer consumer = new QueueingConsumer(queue.channel);
             queue.channel.basicConsume(queue.name, true, consumer);
             Delivery delivery = null;
             while ((terminationMutex.availablePermits() == 0) || (queue.messageCount() > 0) || (delivery != null)) {


### PR DESCRIPTION
Code changes for the classes that were using `QueueingConsumer` as the `Callback` for `basic consumer` in `RabbitMQ-4.8.0`. The updated code uses a `CustomConsumer` class that overrides the `DefaultConsumer` to create a list of `Delivery` which can be used by classes to replace `QueueingConsumer.Delivery`.